### PR TITLE
🐛 fix production infinite loading due to baseUrl not secure

### DIFF
--- a/__tests__/__snapshots__/StripeCheckout.test.js.snap
+++ b/__tests__/__snapshots__/StripeCheckout.test.js.snap
@@ -14,6 +14,7 @@ exports[`<StripeCheckout /> renders props correctly - extra props 1`] = `
   }
   source={
     Object {
+      "baseUrl": "https://stripe.com",
       "html": "
   <html>
     <head>
@@ -82,6 +83,7 @@ exports[`<StripeCheckout /> renders props correctly - options 1`] = `
   }
   source={
     Object {
+      "baseUrl": "https://stripe.com",
       "html": "
   <html>
     <head>
@@ -219,6 +221,7 @@ exports[`<StripeCheckout /> renders props correctly 1`] = `
   }
   source={
     Object {
+      "baseUrl": "https://stripe.com",
       "html": "
   <html>
     <head>

--- a/src/StripeCheckout.js
+++ b/src/StripeCheckout.js
@@ -138,6 +138,8 @@ const StripeCheckoutWebView = (props: Props) => {
           checkoutSessionInput,
           options,
         ),
+        // Ensure an https baseUrl is used to avoid infinite loading on production due to https://github.com/A-Tokyo/react-native-stripe-checkout-webview/issues/10
+        baseUrl: 'https://stripe.com',
         ...webViewProps?.source,
       }}
       onLoadStart={_onLoadStart}


### PR DESCRIPTION
### Description:
- add https://stripe.com as a baseUrl to avoid infinite loading on production due to https://github.com/A-Tokyo/react-native-stripe-checkout-webview/issues/10

closes  https://github.com/A-Tokyo/react-native-stripe-checkout-webview/issues/10