### PR TITLE
🐛 Fix 404-on-success (#138) and locale breaking sessionId checkout (#108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,18 +77,13 @@ export default MyStripeCheckout;
 - `stripePublicKey` (String) - Stripe public key of your project.
 - `checkoutSessionInput` (Object) - Object to be passed to Stripe's `redirectToCheckout` function. [Docs](https://stripe.com/docs/js/checkout/redirect_to_checkout).
   - ```js
+    // Server-side Checkout Session flow
     {
       sessionId: string,
-      successUrl: string,
-      cancelUrl: string,
-      // common
-      customerEmail?: string,
-      billingAddressCollection?: 'required' | 'auto',
-      shippingAddressCollection?: {
-        allowedCountries: Array<string>,
-      },
+      // optional client-side locale hint - see "A note on locale" below
       locale?: string,
     }
+    // Client-only flow
     | {
         clientReferenceId: string,
         successUrl: string,
@@ -106,8 +101,9 @@ export default MyStripeCheckout;
         locale?: string,
       }
     ```
+  - **When using `sessionId`, only `sessionId` is forwarded to Stripe's `redirectToCheckout`.** Stripe.js rejects the call if any other field (`successUrl`, `cancelUrl`, `locale`, ...) is passed alongside `sessionId`, which would prevent Checkout from loading. Configure those options when you create the Checkout Session server-side instead.
 - `onSuccess` (?Function) - Called upon success of the checkout session with `{ ...props, checkoutSessionId: 'CHECKOUT_SESSION_ID' }`
-- `onCancel` (?Function) - Called upon success of the checkout session with `{ ...props }`
+- `onCancel` (?Function) - Called upon cancellation of the checkout session with `{ ...props }`
 - `onLoadingComplete` (?Function) - Called when the Stripe checkout session webpage loads successfully.
 - `options` (?Object) - custom options to display content in the webview
   - `htmlContentLoading` (String) - Html string to display a loading indication. - default: `<h1 id="sc-loading">Loading...</h1>` - note: The loading item is set on the element with id='sc-loading'
@@ -115,6 +111,15 @@ export default MyStripeCheckout;
   - `htmlContentHead` (String) - Html string to inject in head. - default: ''
 - `webViewProps` (?Object) - WebView Component props, spread on the WebView Component.
 - `renderOnComplete` (?(props) => React$Node) - Optional rendering function returning a component to display upon checkout completion. note: You don't need this if your onSuccess and onCancel functions navigate away from the component.
+
+
+## A note on locale
+- **Client-only flow** (`lineItems`/`items`): pass `locale` directly in `checkoutSessionInput` - it is forwarded to `redirectToCheckout`.
+- **Server-side Checkout Session flow** (`sessionId`): the displayed language is determined by the `locale` you set when **creating the Checkout Session server-side** - this is the authoritative source. Stripe.js does not accept `locale` alongside `sessionId`, so it is not forwarded to `redirectToCheckout` (doing so would prevent Checkout from loading). As a convenience, a `locale` passed in `checkoutSessionInput` is still applied as a client-side hint via the Stripe.js constructor (`Stripe(key, { locale })`), which localizes error strings.
+
+
+## Avoiding a 404 on success / cancel
+- The library intercepts the `successUrl`/`cancelUrl` redirect via the WebView's `onShouldStartLoadWithRequest` and **prevents the WebView from navigating to it**, then calls `onSuccess`/`onCancel`. This means your `successUrl`/`cancelUrl` can be a placeholder that does not resolve to a real page - the WebView will never render its (potentially 404) content. Just make sure the URLs follow the [structure above](#important-notes-about-urls).
 
 
 ## Apple Pay and Google Pay

--- a/__tests__/StripeCheckout.test.js
+++ b/__tests__/StripeCheckout.test.js
@@ -129,6 +129,21 @@ describe('<StripeCheckout /> redirect handling', () => {
     );
   });
 
+  it('passes the actual completion url to renderOnComplete', () => {
+    const renderOnComplete = jest.fn(() => null);
+    const wrapper = shallow(render({ renderOnComplete }));
+    const onShouldStartLoadWithRequest = wrapper
+      .find('WebView')
+      .prop('onShouldStartLoadWithRequest');
+
+    onShouldStartLoadWithRequest({ url: SUCCESS_URL });
+    wrapper.update();
+
+    expect(renderOnComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ url: SUCCESS_URL }),
+    );
+  });
+
   it('excludes a url fragment from the parsed checkout session id', () => {
     const onSuccess = jest.fn();
     const wrapper = shallow(render({ onSuccess }));

--- a/__tests__/StripeCheckout.test.js
+++ b/__tests__/StripeCheckout.test.js
@@ -57,3 +57,123 @@ describe('<StripeCheckout />', () => {
     expect(wrapper).toMatchSnapshot();
   });
 });
+
+/**
+ * https://github.com/a-tokyo/react-native-stripe-checkout-webview/issues/138
+ * The success/cancel redirect must be intercepted and blocked so the WebView
+ * never navigates to a (potentially 404) success/cancel URL.
+ */
+describe('<StripeCheckout /> redirect handling', () => {
+  const SUCCESS_URL =
+    'https://example.com/success?sc_checkout=success&sc_sid=cs_test_123';
+  const CANCEL_URL = 'https://example.com/cancel?sc_checkout=cancel';
+  const STRIPE_URL = 'https://checkout.stripe.com/pay/cs_test_123';
+
+  it('blocks navigation and calls onSuccess with the checkout session id', () => {
+    const onSuccess = jest.fn();
+    const wrapper = shallow(render({ onSuccess }));
+    const onShouldStartLoadWithRequest = wrapper
+      .find('WebView')
+      .prop('onShouldStartLoadWithRequest');
+
+    const shouldLoad = onShouldStartLoadWithRequest({ url: SUCCESS_URL });
+
+    expect(shouldLoad).toBe(false);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({ checkoutSessionId: 'cs_test_123' }),
+    );
+  });
+
+  it('blocks navigation and calls onCancel on the cancel url', () => {
+    const onCancel = jest.fn();
+    const wrapper = shallow(render({ onCancel }));
+    const onShouldStartLoadWithRequest = wrapper
+      .find('WebView')
+      .prop('onShouldStartLoadWithRequest');
+
+    const shouldLoad = onShouldStartLoadWithRequest({ url: CANCEL_URL });
+
+    expect(shouldLoad).toBe(false);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows navigation and fires no callback for non-completion urls', () => {
+    const onSuccess = jest.fn();
+    const onCancel = jest.fn();
+    const wrapper = shallow(render({ onSuccess, onCancel }));
+    const onShouldStartLoadWithRequest = wrapper
+      .find('WebView')
+      .prop('onShouldStartLoadWithRequest');
+
+    const shouldLoad = onShouldStartLoadWithRequest({ url: STRIPE_URL });
+
+    expect(shouldLoad).toBe(true);
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('passes an undefined checkout session id when sc_sid is absent', () => {
+    const onSuccess = jest.fn();
+    const wrapper = shallow(render({ onSuccess }));
+    const onShouldStartLoadWithRequest = wrapper
+      .find('WebView')
+      .prop('onShouldStartLoadWithRequest');
+
+    onShouldStartLoadWithRequest({
+      url: 'https://example.com/success?sc_checkout=success',
+    });
+
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({ checkoutSessionId: undefined }),
+    );
+  });
+
+  it('excludes a url fragment from the parsed checkout session id', () => {
+    const onSuccess = jest.fn();
+    const wrapper = shallow(render({ onSuccess }));
+    const onShouldStartLoadWithRequest = wrapper
+      .find('WebView')
+      .prop('onShouldStartLoadWithRequest');
+
+    onShouldStartLoadWithRequest({
+      url: 'https://example.com/success?sc_checkout=success&sc_sid=cs_test_123#done',
+    });
+
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({ checkoutSessionId: 'cs_test_123' }),
+    );
+  });
+
+  it('fires the completion callback exactly once across both handlers', () => {
+    const onSuccess = jest.fn();
+    const wrapper = shallow(render({ onSuccess }));
+    const webView = wrapper.find('WebView');
+    const onShouldStartLoadWithRequest = webView.prop(
+      'onShouldStartLoadWithRequest',
+    );
+    const onLoadStart = webView.prop('onLoadStart');
+
+    onShouldStartLoadWithRequest({ url: SUCCESS_URL });
+    /** the onLoadStart fallback should not re-trigger onSuccess */
+    onLoadStart({ nativeEvent: { url: SUCCESS_URL } });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates to a user provided onShouldStartLoadWithRequest', () => {
+    const userHandler = jest.fn(() => false);
+    const wrapper = shallow(
+      render({ webViewProps: { onShouldStartLoadWithRequest: userHandler } }),
+    );
+    const onShouldStartLoadWithRequest = wrapper
+      .find('WebView')
+      .prop('onShouldStartLoadWithRequest');
+    const request = { url: STRIPE_URL };
+
+    const shouldLoad = onShouldStartLoadWithRequest(request);
+
+    expect(userHandler).toHaveBeenCalledWith(request);
+    expect(shouldLoad).toBe(false);
+  });
+});

--- a/__tests__/__snapshots__/StripeCheckout.test.js.snap
+++ b/__tests__/__snapshots__/StripeCheckout.test.js.snap
@@ -7,6 +7,7 @@ exports[`<StripeCheckout /> renders props correctly - extra props 1`] = `
   javaScriptEnabled={true}
   onLoadEnd={[Function]}
   onLoadStart={[Function]}
+  onShouldStartLoadWithRequest={[Function]}
   originWhitelist={
     Array [
       "*",
@@ -77,6 +78,7 @@ exports[`<StripeCheckout /> renders props correctly - options 1`] = `
   javaScriptEnabled={true}
   onLoadEnd={[Function]}
   onLoadStart={[Function]}
+  onShouldStartLoadWithRequest={[Function]}
   originWhitelist={
     Array [
       "*",
@@ -147,6 +149,7 @@ exports[`<StripeCheckout /> renders props correctly - webViewProps 1`] = `
   javaScriptEnabled={true}
   onLoadEnd={[Function]}
   onLoadStart={[Function]}
+  onShouldStartLoadWithRequest={[Function]}
   originWhitelist={
     Array [
       "https://stripe.com",
@@ -217,6 +220,7 @@ exports[`<StripeCheckout /> renders props correctly 1`] = `
   javaScriptEnabled={true}
   onLoadEnd={[Function]}
   onLoadStart={[Function]}
+  onShouldStartLoadWithRequest={[Function]}
   originWhitelist={
     Array [
       "*",

--- a/__tests__/stripeCheckoutRedirectHTML.test.js
+++ b/__tests__/stripeCheckoutRedirectHTML.test.js
@@ -72,4 +72,46 @@ describe('stripeCheckoutRedirectHTML', () => {
     expect(errorToCheck).toEqual(expect.any(Error));
     expect(errorToCheck.message).toEqual('Must provide redirectToCheckout function input.');
   });
+
+  /**
+   * https://github.com/a-tokyo/react-native-stripe-checkout-webview/issues/108
+   * When using a server-side Checkout Session, Stripe.js only accepts
+   * `{ sessionId }`. Forwarding any extra field (eg: `locale`) breaks Checkout.
+   */
+  it('forwards only sessionId to redirectToCheckout when using a session', () => {
+    const html = stripeCheckoutRedirectHTML('sp_test_stripe_public_key', {
+      sessionId: 'sessionId',
+      locale: 'de',
+    });
+    expect(html).toContain('redirectToCheckout({"sessionId":"sessionId"})');
+    expect(html).not.toContain('redirectToCheckout({"sessionId":"sessionId","locale"');
+  });
+
+  it('applies locale as a constructor hint when provided', () => {
+    const html = stripeCheckoutRedirectHTML('sp_test_stripe_public_key', {
+      sessionId: 'sessionId',
+      locale: 'de',
+    });
+    expect(html).toContain('Stripe(\'sp_test_stripe_public_key\', {"locale":"de"})');
+  });
+
+  it('omits constructor options when no locale is provided', () => {
+    const html = stripeCheckoutRedirectHTML('sp_test_stripe_public_key', {
+      sessionId: 'sessionId',
+    });
+    expect(html).toContain('Stripe(\'sp_test_stripe_public_key\')');
+  });
+
+  it('retains locale in the redirect input for the client-only flow', () => {
+    const html = stripeCheckoutRedirectHTML('sp_test_stripe_public_key', {
+      clientReferenceId: 'clientReferenceId',
+      successUrl: 'https://example.com/success?sc_checkout=success',
+      cancelUrl: 'https://example.com/cancel?sc_checkout=cancel',
+      lineItems: [{ price: 'price_123', quantity: 1 }],
+      mode: 'payment',
+      locale: 'de',
+    });
+    expect(html).toContain('"clientReferenceId":"clientReferenceId"');
+    expect(html).toContain('"locale":"de"');
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-stripe-checkout-webview",
-  "version": "0.0.13",
+  "version": "0.1.0",
   "description": "💰 React Native implementation for Stripe.js Checkout",
   "author": {
     "name": "Ahmed Tarek",

--- a/src/StripeCheckout.js
+++ b/src/StripeCheckout.js
@@ -109,7 +109,7 @@ const StripeCheckoutWebView = (props: Props) => {
          * Stop at a query separator (`&`), path separator (`/`) or fragment (`#`). */
         const sessionIdMatch = currentUrl.match(/sc_sid=([^&/#]+)/);
         const checkoutSessionId = sessionIdMatch ? sessionIdMatch[1] : undefined;
-        setCompleted(true);
+        setCompleted(currentUrl);
         if (onSuccess) {
           onSuccess({ ...props, checkoutSessionId });
         }
@@ -120,7 +120,7 @@ const StripeCheckoutWebView = (props: Props) => {
     if (currentUrl.includes('sc_checkout=cancel')) {
       if (!hasCompletedRef.current) {
         hasCompletedRef.current = true;
-        setCompleted(true);
+        setCompleted(currentUrl);
         if (onCancel) {
           onCancel(props);
         }

--- a/src/StripeCheckout.js
+++ b/src/StripeCheckout.js
@@ -1,5 +1,5 @@
 /* @flow */
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Text } from 'react-native';
 import { WebView } from 'react-native-webview';
 
@@ -10,15 +10,15 @@ type Props = {
   stripePublicKey: string,
   /** Stripe Checkout Session input */
   checkoutSessionInput: {
+    /**
+     * Server-side Checkout Session flow.
+     * Only `sessionId` is forwarded to `stripe.redirectToCheckout`.
+     * Everything else (`successUrl`, `cancelUrl`, `locale`, ...) must be
+     * configured when creating the Checkout Session server-side.
+     * `locale`, if provided, is additionally used as a client-side hint via
+     * the Stripe.js constructor.
+     */
     sessionId: string,
-    successUrl: string,
-    cancelUrl: string,
-    // common
-    customerEmail?: string,
-    billingAddressCollection?: 'required' | 'auto',
-    shippingAddressCollection?: {
-      allowedCountries: Array<string>,
-    },
     locale?: string,
   }
 | {
@@ -79,39 +79,85 @@ const StripeCheckoutWebView = (props: Props) => {
   } = props;
   /** Holds the complete URL if exists */
   const [completed, setCompleted] = useState(null);
-  /** Holds wether Stripe Checkout has loaded yet */
+  /** Holds whether Stripe Checkout has loaded yet */
   const [hasLoaded, setHasLoaded] = useState(false);
+  /**
+   * Tracks whether the checkout completion has already been handled so that
+   * `onSuccess`/`onCancel` fire exactly once even though completion can be
+   * detected from both `onShouldStartLoadWithRequest` and `onLoadStart`.
+   */
+  const hasCompletedRef = useRef(false);
 
   /**
-   * Called everytime the URL stats to load in the webview
+   * Inspects a URL the WebView is about to load and, if it is the Stripe
+   * success/cancel redirect, completes the checkout session.
    *
-   * handles completing the checkout session
+   * @returns {boolean} `true` if the URL was a completion URL (and was handled),
+   *   in which case the caller should prevent the WebView from navigating to it
+   *   - this avoids landing on a 404 when the success/cancel URL is a placeholder
+   *   (see https://github.com/a-tokyo/react-native-stripe-checkout-webview/issues/138).
+   */
+  const _handleCompletionUrl = (currentUrl: string): boolean => {
+    if (!currentUrl) {
+      return false;
+    }
+    /** Check and handle checkout state: success */
+    if (currentUrl.includes('sc_checkout=success')) {
+      if (!hasCompletedRef.current) {
+        hasCompletedRef.current = true;
+        /** Extract the optional `sc_sid` checkout session id - undefined if absent.
+         * Stop at a query separator (`&`), path separator (`/`) or fragment (`#`). */
+        const sessionIdMatch = currentUrl.match(/sc_sid=([^&/#]+)/);
+        const checkoutSessionId = sessionIdMatch ? sessionIdMatch[1] : undefined;
+        setCompleted(true);
+        if (onSuccess) {
+          onSuccess({ ...props, checkoutSessionId });
+        }
+      }
+      return true;
+    }
+    /** Check and handle checkout state: cancel */
+    if (currentUrl.includes('sc_checkout=cancel')) {
+      if (!hasCompletedRef.current) {
+        hasCompletedRef.current = true;
+        setCompleted(true);
+        if (onCancel) {
+          onCancel(props);
+        }
+      }
+      return true;
+    }
+    return false;
+  };
+
+  /**
+   * Called before the WebView loads a URL.
+   *
+   * Returning `false` prevents the WebView from navigating to the success/cancel
+   * URL, so a placeholder/non-existent redirect URL never renders a 404 page.
+   */
+  const _onShouldStartLoadWithRequest = (request: { url: string }): boolean => {
+    if (_handleCompletionUrl(request && request.url)) {
+      /** block navigation to the success/cancel URL */
+      return false;
+    }
+    /** respect a user provided onShouldStartLoadWithRequest */
+    if (webViewProps && webViewProps.onShouldStartLoadWithRequest) {
+      return webViewProps.onShouldStartLoadWithRequest(request);
+    }
+    return true;
+  };
+
+  /**
+   * Called every time the URL starts to load in the WebView.
+   *
+   * Handles completing the checkout session - acts as a fallback for platforms
+   * where `onShouldStartLoadWithRequest` is not invoked for the redirect.
    */
   const _onLoadStart = (syntheticEvent: SyntheticEvent) => {
     const { nativeEvent } = syntheticEvent;
     const { url: currentUrl } = nativeEvent;
-    /** Check and handle checkout state: success */
-    if (currentUrl.includes('sc_checkout=success')) {
-      const checkoutSessionIdKey = 'sc_sid=';
-      const checkoutSessionId = currentUrl
-        .substring(currentUrl.indexOf(checkoutSessionIdKey), currentUrl.length)
-        /** remove key */
-        .replace(checkoutSessionIdKey, '')
-        /** remove extra trailing slash */
-        .replace('/', '');
-      setCompleted(true);
-      if (onSuccess) {
-        onSuccess({ ...props, checkoutSessionId });
-      }
-      return;
-    }
-    /** Check and handle checkout state: cancel */
-    if (currentUrl.includes('sc_checkout=cancel')) {
-      setCompleted(true);
-      if (onCancel) {
-        onCancel(props);
-      }
-    }
+    _handleCompletionUrl(currentUrl);
     /** call webViewProps.onLoadStart */
     if (webViewProps && webViewProps.onLoadStart) {
       webViewProps.onLoadStart(syntheticEvent);
@@ -160,6 +206,7 @@ const StripeCheckoutWebView = (props: Props) => {
         baseUrl: 'https://stripe.com',
         ...webViewProps?.source,
       }}
+      onShouldStartLoadWithRequest={_onShouldStartLoadWithRequest}
       onLoadStart={_onLoadStart}
       onLoadEnd={_onLoadEnd}
     />

--- a/src/stripeCheckoutRedirectHTML.js
+++ b/src/stripeCheckoutRedirectHTML.js
@@ -7,15 +7,15 @@ const stripeCheckoutRedirectHTML = (
   stripe_public_key: string,
   input:
     | {
+        /**
+         * Server-side Checkout Session flow.
+         * Only `sessionId` is forwarded to `stripe.redirectToCheckout`.
+         * Everything else (`successUrl`, `cancelUrl`, `locale`, ...) must be
+         * configured when creating the Checkout Session server-side.
+         * `locale`, if provided, is additionally used as a client-side hint via
+         * the Stripe.js constructor.
+         */
         sessionId: string,
-        successUrl: string,
-        cancelUrl: string,
-        // common
-        customerEmail?: string,
-        billingAddressCollection?: 'required' | 'auto',
-        shippingAddressCollection?: {
-          allowedCountries: Array<string>,
-        },
         locale?: string,
       }
     | {
@@ -57,6 +57,33 @@ const stripeCheckoutRedirectHTML = (
     htmlContentHead = '',
   } = options || {};
 
+  /**
+   * Build the input passed to `stripe.redirectToCheckout`.
+   *
+   * When a server-side Checkout Session is used, Stripe.js only accepts
+   * `{ sessionId }` - passing any other field (eg: `locale`, `successUrl`)
+   * makes Stripe.js reject the call and the checkout never loads.
+   * See https://github.com/a-tokyo/react-native-stripe-checkout-webview/issues/108
+   *
+   * For the session flow, all other settings (including `locale`) must be set
+   * server-side when creating the Checkout Session. For the client-only flow
+   * (lineItems/items) the full input - including `locale` - is forwarded.
+   *
+   * `'sessionId' in input` is used so Flow can narrow the union before reading
+   * `input.sessionId` (it does not exist on the client-only member).
+   */
+  const redirectToCheckoutInput =
+    'sessionId' in input ? { sessionId: input.sessionId } : input;
+
+  /**
+   * `locale` is applied at the Stripe.js constructor level so it can localize
+   * Checkout (and error strings) even when using a server-side session, where
+   * `locale` cannot be passed to `redirectToCheckout`.
+   */
+  const stripeConstructorOptions = input.locale
+    ? { locale: input.locale }
+    : null;
+
   /** Return html */
   return `
   <html>
@@ -78,11 +105,15 @@ const stripeCheckoutRedirectHTML = (
       <!-- Stripe execution script -->
       <script>
         (function initStripeAndRedirectToCheckout () {
-          const stripe = Stripe('${stripe_public_key}');
+          const stripe = Stripe('${stripe_public_key}'${
+            stripeConstructorOptions
+              ? `, ${JSON.stringify(stripeConstructorOptions)}`
+              : ''
+          });
           window.onload = () => {
             console.log('RNSC: window loaded');
             // Redirect to Checkout
-            stripe.redirectToCheckout(${JSON.stringify(input)})
+            stripe.redirectToCheckout(${JSON.stringify(redirectToCheckoutInput)})
             .then((result) => {
                 console.log('RNSC: window loaded', result);
                 // Remove loading html


### PR DESCRIPTION
## Summary

Fixes two open issues:

- **#138 — Getting a 404 on success**
- **#108 — Locale not working**

Both are reproducible from the source and are covered by new tests.

---

### #138 — 404 on success

**Root cause:** the success/cancel redirect was only handled in `onLoadStart`, which fires *after* navigation has already started. The WebView still navigates to the `successUrl`/`cancelUrl` — often a placeholder/deep-link that doesn't resolve — so its 404 page can render before React swaps in the completion view. There was no mechanism to *prevent* the navigation.

**Fix:** add an `onShouldStartLoadWithRequest` handler that detects the `sc_checkout=success` / `sc_checkout=cancel` redirect and returns `false`, so the WebView **never navigates** to the success/cancel URL. Completion logic is shared with `onLoadStart` (kept as a fallback for platforms where `onShouldStartLoadWithRequest` isn't invoked for a JS redirect) and guarded by a `useRef` so `onSuccess`/`onCancel` fire **exactly once**. It also delegates to a user-provided `webViewProps.onShouldStartLoadWithRequest` for other URLs.

Also fixes a latent bug in the `sc_sid` parser: when `sc_sid` was absent, `indexOf` returned `-1` and `checkoutSessionId` became the *entire URL*. It now extracts the value via regex and yields `undefined` when absent.

### #108 — Locale not working

**Root cause:** the whole `checkoutSessionInput` was passed to `stripe.redirectToCheckout`. Per Stripe.js, the server-side session form accepts **only** `{ sessionId }` (`RedirectToCheckoutServerOptions`); `locale` (and `successUrl`/`cancelUrl`) belong to the client-only form. Passing `{ sessionId, locale }` makes Stripe.js reject the call, so Checkout never loads.

**Fix:** when a `sessionId` is provided, forward **only** `{ sessionId }` to `redirectToCheckout`. The user's `locale` is honored as far as Stripe.js allows by applying it at the constructor level — `Stripe(key, { locale })`. The client-only flow (`lineItems`/`items`) keeps forwarding `locale` as before. The README documents that, for the session flow, `locale` is authoritative when the Checkout Session is created server-side.

---

## Tests

- `stripeCheckoutRedirectHTML`: only `sessionId` forwarded for the session flow; `locale` applied as a constructor hint; constructor options omitted when no locale; `locale` retained for the client-only flow.
- `StripeCheckout`: `onShouldStartLoadWithRequest` blocks success/cancel navigation and calls `onSuccess`/`onCancel` (with parsed `checkoutSessionId`, `undefined` when `sc_sid` absent); allows non-completion URLs; fires the callback exactly once across both handlers; delegates to a user-provided handler.

`yarn test` (build + jest) passes — **20/20** tests green, coverage above thresholds. The only snapshot change is the added `onShouldStartLoadWithRequest` prop; existing `sessionId`-only HTML is unchanged (backward compatible).

Closes #138
Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)