### PR TITLE
🐛 Pass the actual completion URL to renderOnComplete (was `true`)

### DIFF
--- a/__tests__/StripeCheckout.test.js
+++ b/__tests__/StripeCheckout.test.js
@@ -129,6 +129,21 @@ describe('<StripeCheckout /> redirect handling', () => {
     );
   });
 
+  it('passes the actual completion url to renderOnComplete', () => {
+    const renderOnComplete = jest.fn(() => null);
+    const wrapper = shallow(render({ renderOnComplete }));
+    const onShouldStartLoadWithRequest = wrapper
+      .find('WebView')
+      .prop('onShouldStartLoadWithRequest');
+
+    onShouldStartLoadWithRequest({ url: SUCCESS_URL });
+    wrapper.update();
+
+    expect(renderOnComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ url: SUCCESS_URL }),
+    );
+  });
+
   it('excludes a url fragment from the parsed checkout session id', () => {
     const onSuccess = jest.fn();
     const wrapper = shallow(render({ onSuccess }));

--- a/src/StripeCheckout.js
+++ b/src/StripeCheckout.js
@@ -109,7 +109,7 @@ const StripeCheckoutWebView = (props: Props) => {
          * Stop at a query separator (`&`), path separator (`/`) or fragment (`#`). */
         const sessionIdMatch = currentUrl.match(/sc_sid=([^&/#]+)/);
         const checkoutSessionId = sessionIdMatch ? sessionIdMatch[1] : undefined;
-        setCompleted(true);
+        setCompleted(currentUrl);
         if (onSuccess) {
           onSuccess({ ...props, checkoutSessionId });
         }
@@ -120,7 +120,7 @@ const StripeCheckoutWebView = (props: Props) => {
     if (currentUrl.includes('sc_checkout=cancel')) {
       if (!hasCompletedRef.current) {
         hasCompletedRef.current = true;
-        setCompleted(true);
+        setCompleted(currentUrl);
         if (onCancel) {
           onCancel(props);
         }


### PR DESCRIPTION
## Summary

Small, standalone fix split out of #143 (stacked on top of it).

`StripeCheckout` documents its `completed` state as *"the complete URL"* and passes it to `renderOnComplete` as `{ url: completed, ...props }`. But on success/cancel it was set to the boolean `true`, so `renderOnComplete` received **`url: true`** instead of the real redirect URL. This sets it to the completion URL on both paths.

## Why this is non-breaking

- The `if (completed)` gate is unchanged — a non-empty URL is truthy just like `true`, and `completed` is only ever set from a non-empty `sc_checkout=success`/`cancel` URL, so it can't become falsy.
- The public type is `renderOnComplete?: () => React$Node` (declared to take **no** arguments), so type-conformant consumers read nothing from it.
- The only observable difference: a consumer who reads `props.url` inside `renderOnComplete` now receives the actual URL string instead of the meaningless `true`.

## Tests

Adds a test asserting `renderOnComplete` is called with the real completion URL. Full suite: **22/22 green**.

## Note

Base is the `#143` branch (stacked PR) so the diff stays minimal. Once #143 merges, this will auto-retarget to `main` — or merge #143 first, then this.