### PR TITLE
ci: migrate release pipeline to npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -2,52 +2,86 @@ name: Test Release Publish
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: write
+  id-token: write
 
 jobs:
-  test_release_publish:
-    name: Running tests and releasing to NPM
+  test:
+    name: Run tests
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Get yarn cache
         id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ubuntu-latest-node-12.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ubuntu-latest-node-24.x-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ubuntu-latest-node-12.x-yarn-
-      - uses: actions/setup-node@v1
+            ubuntu-latest-node-24.x-yarn-
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: '24.x'
           registry-url: https://registry.npmjs.org/
       - name: Install
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Test
         run: yarn test --ci --bail
+
+  release_publish:
+    name: Release to Github and publish to NPM
+    runs-on: ubuntu-latest
+    needs: test
+    if: success() && github.ref == 'refs/heads/main'
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ubuntu-latest-node-24.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ubuntu-latest-node-24.x-yarn-
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+          registry-url: https://registry.npmjs.org/
+      - name: Install
+        run: yarn install --frozen-lockfile
       # - name: Build
       #   run: NODE_ENV=production yarn build
       - name: Setup env vars
         id: ownEnvVars
         run: |
-          # Set PACKAGE_VERSION
           PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
-          echo ::set-output name=PACKAGE_VERSION::$PACKAGE_VERSION
-          # Set COMMIT_LOG
-          COMMIT_LOG=`git log $(git describe --tags --abbrev=0)..HEAD --format='%s - %an'`
-          echo ::set-output name=COMMIT_LOG::$COMMIT_LOG
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
+          echo "COMMIT_LOG<<EOF" >> $GITHUB_ENV
+          git log $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD --format='- %s (%an)' >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Check if version already released
+        id: check_tag
+        run: |
+          if git rev-parse "refs/tags/${{ env.PACKAGE_VERSION }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
       - uses: ncipollo/release-action@v1
+        if: steps.check_tag.outputs.exists == 'false'
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.ownEnvVars.outputs.PACKAGE_VERSION }}
+          tag: ${{ env.PACKAGE_VERSION }}
           commit: main
-          body: ${{ steps.ownEnvVars.outputs.COMMIT_LOG }}
+          body: ${{ env.COMMIT_LOG }}
       - name: npm publish
+        if: steps.check_tag.outputs.exists == 'false'
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        if: github.event.pull_request.user.login != 'dependabot'


### PR DESCRIPTION
## What

Migrate the GitHub release pipeline to the "new way" used in `apple-signin-auth` / `react-apple-signin-auth`.

- Split the combined job into separate **`test`** and **`release_publish`** jobs (release runs only on `main`).
- Bump Node **12.x → 24.x**, modernize actions (`actions/*@v1 → @v4`), and replace the deprecated `::set-output` syntax with `$GITHUB_OUTPUT` / `$GITHUB_ENV`.
- Publish via **npm OIDC trusted publishing**: removed the `NPM_TOKEN` secret, added `id-token: write` and `environment: production`.
- Added a **tag-exists guard**, `fetch-depth: 0`, and a first-release-safe changelog.
- Dropped the obsolete `dependabot` publish guard (release no longer runs on PRs).

## Build step (intentional)

The Build step stays **commented out** to preserve current behavior. `package.json` `main` is `src/index.js` and `src/` is always in `files`, so the publish ships source directly and consumers are unaffected. Build is still validated in CI via the `test` job's `yarn test` (which builds).

## Note

Publishing only succeeds once the npm **trusted publisher** is configured for `react-native-stripe-checkout-webview` (org/repo `a-tokyo/react-native-stripe-checkout-webview`, workflow file `test-publish.yml`, environment `production`) — handled in a separate npm-side change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
